### PR TITLE
typo fix Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This will allow you to use passkeys that have been created on any app that uses 
 
   
 
-CapsuleSwift provides an interface to Capsule services from within iOS applications using SwiftUI (Support for UIKit comming soon).
+CapsuleSwift provides an interface to Capsule services from within iOS applications using SwiftUI (Support for UIKit coming soon).
 
   
 


### PR DESCRIPTION
### Description 
During the process of reviewing the documentation, a minor typo was discovered in the following sentence:

> "Support for UIKit **comming** soon".

The word "**comming**" has been corrected to "**coming**" to ensure proper spelling.

Corrected version:  
> "Support for UIKit **coming** soon".

This change improves the clarity and accuracy of the documentation.